### PR TITLE
Use install for nvm to get auto-install behavior

### DIFF
--- a/bin/switcher.js
+++ b/bin/switcher.js
@@ -5,7 +5,7 @@ var spawn = require('child_process').spawn
 function Switcher (version) {
   var binArgs = {
     n: ['n', version],
-    nvm: [process.env.SHELL, '-c', 'source $NVM_DIR/nvm.sh; nvm use ' + version]
+    nvm: [process.env.SHELL, '-c', 'source $NVM_DIR/nvm.sh; nvm install ' + version]
   }
 
   function switcher (bin) {


### PR DESCRIPTION
`nvm install` will try to install and then switch to the desired version.  It's safe if the version is already installed.
