### PR TITLE
feat(migrate): auto reinstall global packages

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -28,7 +28,7 @@ if (!nodeVersion) processExit()
 config(function (nodeVersions) {
   var maxNodeVersion = semver.maxSatisfying(nodeVersions, nodeVersion)
 
-  var switcher = Switcher(maxNodeVersion)
+  var switcher = Switcher(maxNodeVersion, nodeVersion)
   var switcherBin = null
 
   function getBin (next) {

--- a/bin/switcher.js
+++ b/bin/switcher.js
@@ -2,11 +2,14 @@
 
 var spawn = require('child_process').spawn
 
-function Switcher (version) {
+function Switcher (version, currentVersion) {
+  var installCmd = 'nvm install ' + version;
+  installCmd += (currentVersion) ? ' --reinstall-packages-from=" + currentVersion : '';
+  
   var binaries = {
     nvm: {
       cmd: process.env.SHELL,
-      args: ['-c', 'source $NVM_DIR/nvm.sh; nvm install ' + version]
+      args: ['-c', 'source $NVM_DIR/nvm.sh; ' + installCmd]
     },
 
     n: {

--- a/bin/switcher.js
+++ b/bin/switcher.js
@@ -4,7 +4,7 @@ var spawn = require('child_process').spawn
 
 function Switcher (version, currentVersion) {
   var installCmd = 'nvm install ' + version;
-  installCmd += (currentVersion) ? ' --reinstall-packages-from=" + currentVersion : '';
+  installCmd += (currentVersion) ? ' --reinstall-packages-from=' + currentVersion : '';
   
   var binaries = {
     nvm: {

--- a/bin/switcher.js
+++ b/bin/switcher.js
@@ -3,9 +3,9 @@
 var spawn = require('child_process').spawn
 
 function Switcher (version, currentVersion) {
-  var installCmd = 'nvm install ' + version;
-  installCmd += (currentVersion) ? ' --reinstall-packages-from=' + currentVersion : '';
-  
+  var installCmd = 'nvm install ' + version
+  installCmd += (currentVersion) ? ' --reinstall-packages-from=' + currentVersion : ''
+
   var binaries = {
     nvm: {
       cmd: process.env.SHELL,


### PR DESCRIPTION
When installing a new version of node, automatically
reinstall previously globally installed packages thanks
to the `--reinstall-packages-from` arg.
