### PR TITLE
fix(bash): return the newly installed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ chpwd () {
 
   if [ -f $FILE ];
   then
-     installedVersion=$(nodengine | tail -n 1) && nvm use $installedVersion
+     installedVersion=$(nodengine | tail -n 1) && [ -n "$installedVersion" ] && nvm use $installedVersion
   fi
 }
 ```  

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ chpwd () {
 
   if [ -f $FILE ];
   then
-     nodengine
+     installedVersion=$(nodengine | tail -n 1) && nvm use $installedVersion
   fi
 }
 ```  

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Manual switching can be avoided.  Add the following below to your environment de
 ```bash
 echo "\nchpwd () {\n nodengine\n}" >> ~/.zshrc
 ```
-### Bash
+### Bash (with other version manager than NVM)
 
 ```bash
 # Enable nodengine autoswitching
@@ -57,10 +57,32 @@ chpwd () {
 
   if [ -f $FILE ];
   then
-     installedVersion=$(nodengine | tail -n 1) && [ -n "$installedVersion" ] && nvm use $installedVersion
+     nodengine
   fi
 }
-```  
+``` 
+
+### Bash and NVM
+
+There is a problem when using NVM and bash where your current shell isn't updated when a new version is selected/installed.
+You should do the following to fix this problem:
+
+```bash
+# Enable nodengine autoswitching
+cd () { builtin cd "$@" && chpwd; }
+pushd () { builtin pushd "$@" && chpwd; }
+popd () { builtin popd "$@" && chpwd; }
+chpwd () {
+  FILE=$PWD/package.json
+
+  if [ -f $FILE ];
+  then
+    # With NVM, nodengine returns the selected/installed version so that we can use it
+    # to force select the version to use in the current shell
+    installedVersion=$(nodengine | tail -n 1) && [ -n "$installedVersion" ] && nvm use $installedVersion
+  fi
+}
+``` 
 
 ## License
 

--- a/bin/index.js
+++ b/bin/index.js
@@ -48,7 +48,7 @@ config(function (versions) {
     if (switcherBin) {
       var switcherProcess = switcher(switcherBin)
 
-      switcherProcess.on('close', function(code) {
+      switcherProcess.on('close', function (code) {
         if (code === 0) {
           console.log(maxSatisfyVersion)
         }

--- a/bin/index.js
+++ b/bin/index.js
@@ -45,6 +45,16 @@ config(function (versions) {
   }
 
   async.doWhilst(getBin, whileCondition, function () {
-    if (switcherBin) return switcher(switcherBin)
+    if (switcherBin) {
+      var switcherProcess = switcher(switcherBin)
+
+      switcherProcess.on('close', function(code) {
+        if (code === 0) {
+          console.log(maxSatisfyVersion)
+        }
+      })
+
+      return switcherProcess
+    }
   })
 })


### PR DESCRIPTION
This way, it's possible to execute a `nvm use` with the
new installed version so that the parent shell can use
this new version right away.

Also, update the doc for the auto-switching.
