### PR TITLE
Show node version after auto switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,27 +40,25 @@ It will use the highest version that satisfies the range.
 ## Automatic switching
 Manual switching can be avoided.  Add the following below to your environment depending on your shell choice.
 
-### Zsh
+### Zsh and Bash
 
-```bash
-echo "\nchpwd () {\n nodengine\n}" >> ~/.zshrc
-```
-### Bash
-
-```bash
+```shell
 # Enable nodengine autoswitching
-cd () { builtin cd "$@" && chpwd; }
-pushd () { builtin pushd "$@" && chpwd; }
-popd () { builtin popd "$@" && chpwd; }
-chpwd () {
-  FILE=$PWD/package.json
+if hash nodengine 2>/dev/null; then
+  function cd () { builtin cd "$@" && chpwd; }
+  pushd () { builtin pushd "$@" && chpwd; }
+  popd () { builtin popd "$@" && chpwd; }
+  function chpwd () {
+    FILE=$PWD/package.json
 
-  if [ -f $FILE ];
-  then
-     nodengine
-  fi
-}
-```  
+    if [ -f $FILE ] && [ "$LAST_NODENGINE_DIR" != "$PWD" ]; then
+      nodengine
+      builtin echo "changed to node $(node --version)"
+      LAST_NODENGINE_DIR="$PWD"
+    fi
+  }
+fi
+```
 
 ## License
 


### PR DESCRIPTION
Updates shell code for auto switching to echo new node version after switching.

Also, the `nodengine` command appears to run twice (add a `date +%s%6N` after `nodengine` to see for yourself), so I've added a few lines that ensure it only runs once.

Additionally, the code seems to work fine in Zsh as well as Bash, so I've combined those two sections.

Finally, I've added code to ensure nodengine is actually installed before enabling auto-switching. I use this in [my dotfiles](https://github.com/johntron/dotfiles), and want to make sure my shell works if I haven't installed nodengine on a particular machine - feel free to remove this outer conditional.
