### PR TITLE
Fixes #32 - error prone zsh syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,7 @@ Enabling automatic switching consist in a little shell script for check if `pack
 Add the follow snippet in a file loaded by your shell agent, for example, `.extra`.
 
 ```bash
-cd () { builtin cd "$@" && chpwd; }
-pushd () { builtin pushd "$@" && chpwd; }
-popd () { builtin popd "$@" && chpwd; }
-
-chpwd () {
+function chpwd() {
   local PKG
   PKG=$PWD/package.json
   if [ -f "$PKG" ] && [ "$NODENGINE_LAST_DIR" != "$PWD" ]; then
@@ -57,6 +53,10 @@ chpwd () {
     NODENGINE_LAST_DIR=$PWD
   fi
 }
+
+function cd() { builtin cd "$@" && chpwd; }
+function pushd() { builtin pushd "$@" && chpwd; }
+function popd() { builtin popd "$@" && chpwd; }
 ```
 
 ## Fetching new versions


### PR DESCRIPTION
Fixes #32
The old syntax started erroring with zsh 5.4.1.  This new change is confirmed working.  Note that the `chpwd` function used does need to be declared (it seems) before the others.