### PR TITLE
fix: handle semver.io being down or under maintenance

### DIFF
--- a/bin/config.js
+++ b/bin/config.js
@@ -16,7 +16,9 @@ function loadConfig (cb) {
     function checkCache (next) {
       const currentNodeVersions = config.get('nodeVersions')
       const lastFetchCheck = config.get('lastFetchCheck')
-      const hasVersions = currentNodeVersions.length
+      const hasVersions =
+        // Ignore corrupted cached versions (due to HTML error page).
+        currentNodeVersions.length && !currentNodeVersions[0].includes("html");
       const now = Date.now()
       const isCacheValid = now - lastFetchCheck < fetchCheckInterval
 
@@ -27,6 +29,10 @@ function loadConfig (cb) {
           // no internet!
           if (err.code === 'ENOTFOUND') return next(null, currentNodeVersions)
           return next(err)
+        }
+        
+        if (!nodeVersions || nodeVersions.length === 0) {
+          return next(new Error('No NodeJS versions found!'))
         }
 
         config.set('nodeVersions', nodeVersions)

--- a/bin/fetch.js
+++ b/bin/fetch.js
@@ -1,14 +1,16 @@
 'use strict'
 
 const get = require('simple-get')
-const URL = 'https://semver.io/node/versions'
+const URL = 'https://nodejs.org/dist/index.json'
 
-function fetch (cb) {
+function fetch(cb) {
   get.concat(URL, function (err, res, data) {
     if (err) return cb(err)
-    const nodeVersions = data.toString().split('\n')
+    const nodeVersions = JSON.parse(data.toString()).map(function (versionItem) {
+      return versionItem.version.replace(/^v/, '')
+    })
 
-    // When the semver.io service is down, it returns an HTML error page.
+    // When the nodejs.org service is down, it returns an HTML error page.
     // For example, when in maintenance mode, we get a Heroku maintenance page.
     if (nodeVersions[0].includes('html')) {
       return cb(

--- a/bin/fetch.js
+++ b/bin/fetch.js
@@ -7,6 +7,17 @@ function fetch (cb) {
   get.concat(URL, function (err, res, data) {
     if (err) return cb(err)
     const nodeVersions = data.toString().split('\n')
+
+    // When the semver.io service is down, it returns an HTML error page.
+    // For example, when in maintenance mode, we get a Heroku maintenance page.
+    if (nodeVersions[0].includes('html')) {
+      return cb(
+        new Error(
+          `Unable to fetch NodeJS versions from "${URL}" (maybe it's down or under maintenance)`
+        )
+      )
+    }
+
     return cb(null, nodeVersions)
   })
 }

--- a/bin/switch.js
+++ b/bin/switch.js
@@ -11,9 +11,9 @@ function _switch (nodeVersion) {
     function loadConfig (next) {
       return config(next)
     },
-    function getSwitcher (versions, next) {
+    function getSwitcher (nodeVersions, next) {
       const currentVersion = process.versions.node
-      const maxSatisfyVersion = semver.maxSatisfying(versions, nodeVersion)
+      const maxSatisfyVersion = semver.maxSatisfying(nodeVersions, nodeVersion)
 
       // If the cache of nodes versions is corrupted (e.g. with an HTML error
       // page) or empty, we'll have a `null` version here. So instad of

--- a/bin/switch.js
+++ b/bin/switch.js
@@ -14,8 +14,18 @@ function _switch (nodeVersion) {
     function getSwitcher (versions, next) {
       const currentVersion = process.versions.node
       const maxSatisfyVersion = semver.maxSatisfying(versions, nodeVersion)
-      const switcher = createSwitcher(maxSatisfyVersion, currentVersion)
 
+      // If the cache of nodes versions is corrupted (e.g. with an HTML error
+      // page) or empty, we'll have a `null` version here. So instad of
+      // displaying the not so clear error message of N/NVM, we'll output a more
+      // explicit one.
+      if (maxSatisfyVersion === null) {
+        return next(
+          new Error(`No maximum satisfying version found for "${nodeVersion}"`)
+        )
+      }
+
+      const switcher = createSwitcher(maxSatisfyVersion, currentVersion)
       switcher.getBin(function (err, bin) {
         return next(err, switcher, bin)
       })


### PR DESCRIPTION
Do not corrupt the existing versions cache and display easier to understand errors when there has been an issue downloading the NodeJS version from [semver.io](https://semver.io).

For example, today, the 3rd of October, 2022, semver.io is returning:
![image](https://user-images.githubusercontent.com/6450505/193590155-178644ac-e15f-46b6-8655-37535967f603.png)

This case wasn't handled in Nodengine and as my cache was expired, it stored the HTML code of the maintenance page as NodeJS version.  
Then, computing the max matching version failed and it resulted in N being run with `null` as a NodeJS version.  
I then had a weird N error message when running Nodengine (through automatic switching) and make it hard to understand what was happening.

![image](https://user-images.githubusercontent.com/6450505/193590983-f9253d23-f103-4b56-957d-3855a3d681ff.png)

So now, we first properly handle the case where we have an HTML page returned, then we don't corrupt the cache with such HTML page and use the already cached version instead. Finally, we display proper error message to understand where the problem is.

![image](https://user-images.githubusercontent.com/6450505/193591102-0ea441f8-d191-472d-850d-d5e3c8f447ef.png)
![image](https://user-images.githubusercontent.com/6450505/193591057-14788ace-ee97-4da7-b843-813521e6fa8e.png)